### PR TITLE
Change discord links

### DIFF
--- a/cogs/help.py
+++ b/cogs/help.py
@@ -62,7 +62,7 @@ class Help(commands.Cog):
                     commands.append(f"`{command.name}`")
             list_embed.add_field(name=name, value=", ".join(commands), inline=False)
 
-        list_embed.add_field(name="Links", value="[Apply as Dev](https://discord.gg/SQebkz9) | [Vote](https://top.gg/bot/630106665387032576/vote) | [Invite the Bot to your server](https://discordapp.com/oauth2/authorize?client_id=630106665387032576&scope=bot&permissions=8) | [Support Server](https://discord.gg/hmmfXud) | [Todos](https://trello.com/b/2yBAtx82/skybot-rewrite) | [GitHub repo](https://github.com/Skybot-dev/Skybot-rewrite)", inline=False)
+        list_embed.add_field(name="Links", value="[Apply as Dev](https://discord.gg/r99PR8K) | [Vote](https://top.gg/bot/630106665387032576/vote) | [Invite the Bot to your server](https://discordapp.com/oauth2/authorize?client_id=630106665387032576&scope=bot&permissions=8) | [Support Server](https://discord.gg/mHrw5Tt) | [Todos](https://trello.com/b/2yBAtx82/skybot-rewrite) | [GitHub repo](https://github.com/Skybot-dev/Skybot-rewrite)", inline=False)
         return list_embed
 
     @help.command()

--- a/cogs/help.py
+++ b/cogs/help.py
@@ -62,7 +62,7 @@ class Help(commands.Cog):
                     commands.append(f"`{command.name}`")
             list_embed.add_field(name=name, value=", ".join(commands), inline=False)
 
-        list_embed.add_field(name="Links", value="[Apply as Dev](https://discord.gg/r99PR8K) | [Vote](https://top.gg/bot/630106665387032576/vote) | [Invite the Bot to your server](https://discordapp.com/oauth2/authorize?client_id=630106665387032576&scope=bot&permissions=8) | [Support Server](https://discord.gg/mHrw5Tt) | [Todos](https://trello.com/b/2yBAtx82/skybot-rewrite) | [GitHub repo](https://github.com/Skybot-dev/Skybot-rewrite)", inline=False)
+        list_embed.add_field(name="Links", value="[Contribute](https://discord.gg/r99PR8K) | [Vote](https://top.gg/bot/630106665387032576/vote) | [Invite the Bot to your server](https://discordapp.com/oauth2/authorize?client_id=630106665387032576&scope=bot&permissions=8) | [Support Server](https://discord.gg/mHrw5Tt) | [Todos](https://trello.com/b/2yBAtx82/skybot-rewrite) | [GitHub repo](https://github.com/Skybot-dev/Skybot-rewrite)", inline=False)
         return list_embed
 
     @help.command()


### PR DESCRIPTION
Discord links were not working last night, at least for me, so I went in and edited them to the correct ones. Apply as dev leads to #how-to-contribute, and support leads to #rules